### PR TITLE
feat: Add fixed types for trade stat filters

### DIFF
--- a/src/poe/shared/trade/query/Query.ts
+++ b/src/poe/shared/trade/query/Query.ts
@@ -190,10 +190,18 @@ export interface WeaponFilters {
 }
 
 export interface StatFilter {
-  type: string;
+  type: StatFilterType;
   filters: Stat[];
   value?: Range;
   disabled?: boolean;
+}
+
+export enum StatFilterType {
+  And = "and",
+  Not = "not",
+  Count = "count",
+  Weight = "weight",
+  If = "if",
 }
 
 export interface Stat {

--- a/tests/poe/public/Trade.test.ts
+++ b/tests/poe/public/Trade.test.ts
@@ -22,6 +22,7 @@ import {
   ExchangeResults,
 } from "../../../src/poe/shared/trade/query/exchange";
 import { FetchResult } from "../../../src/poe/shared/trade/query/fetch";
+import { StatFilterType } from "../../../src/poe/shared/trade/query/Query";
 
 if (process.env.MOCHA_WORKER_ID) mochaGlobalSetup();
 
@@ -151,7 +152,7 @@ describe("Path of Exile - PublicAPI - Trade", function () {
 
     it(`#search(${league}, query) - should return search results`, async () => {
       const query: SearchQueryContainer = {
-        query: { status: { option: "online" }, stats: [{ type: "and", filters: [] }] },
+        query: { status: { option: "online" }, stats: [{ type: StatFilterType.And, filters: [] }] },
         sort: { price: "asc" },
       };
 


### PR DESCRIPTION
The type for a trade stat filter is now limited by an enum that contains all possible types.